### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cassiomarques/memoria/security/code-scanning/5](https://github.com/cassiomarques/memoria/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs inherit least-privilege token scopes by default.

Best single fix without changing behavior:
- Insert, near the top of the workflow (after `name` and before `on`), a root-level:
  - `permissions:`
  - `contents: read`

This satisfies CodeQL’s minimal recommendation and keeps current workflow functionality intact for checkout/build/test/lint/vulncheck.  
(If later a job needs write scopes, add job-level overrides only for that job.)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
